### PR TITLE
feat: enable scrolling when the canvas is bigger than the parent container

### DIFF
--- a/src/VueDag.vue
+++ b/src/VueDag.vue
@@ -5,6 +5,7 @@
     @mousemove="handleMouseMove"
     @mouseup="handleMouseUp"
     @mousedown="handleMouseDown"
+    @click="deSelectNode"
   >
     <template v-if="edges" #edges>
       <DAGEdge
@@ -199,6 +200,9 @@ export default defineComponent({
             this.mouse.lastX = e.pageX || e.clientX + document.documentElement.scrollLeft;
             this.mouse.lastY = e.pageY || e.clientY + document.documentElement.scrollTop;
         },
+        deSelectNode(e: MouseEvent, node: null) {
+            this.selected = null;
+        },
         handleMouseMove(e: MouseEvent): void {
             if (this.dragging) {
                 this.mouse.x = e.pageX || e.clientX + document.documentElement.scrollLeft;
@@ -222,7 +226,9 @@ export default defineComponent({
         },
         handleMouseDown(e: MouseEvent): void {
             const { target } = e;
-            this.dragging = true;
+            if (this.selected) {
+                this.dragging = true;
+            }
         },
         moveSelectedNode(dx: number, dy: number): void {
             if (!this.selected || !this.selected.x || !this.selected.y) return;

--- a/src/components/DAGContainer.vue
+++ b/src/components/DAGContainer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="vd__container">
-    <svg :width="width" :height="height">
+    <svg :width="width" :height="height" style="overflow: visible">
       <slot name="edges" />
     </svg>
 

--- a/src/scss/vue-dag.scss
+++ b/src/scss/vue-dag.scss
@@ -16,7 +16,7 @@ $vd-node-box-shadow: 0 0 4px 0 $vd-node-box-shadow-color !default;
 
 	margin: 0;
 	position: relative;
-	overflow: hidden;
+	overflow: scroll;
 	height: 100%;
 }
 


### PR DESCRIPTION
This PR also fixes a dragging bug that makes a node follow the mouse even if the the user is not moving it